### PR TITLE
attach ns field on symbol

### DIFF
--- a/example/calcit.cirru
+++ b/example/calcit.cirru
@@ -9,6 +9,21 @@
           :data $ {}
             |T $ {} (:type :leaf) (:by |u0) (:at 1616315471762) (:text |ns)
             |j $ {} (:type :leaf) (:by |u0) (:at 1616315471762) (:text |app.main)
+            |r $ {} (:type :expr) (:by |u0) (:at 1617208837057)
+              :data $ {}
+                |T $ {} (:type :leaf) (:by |u0) (:at 1617208840344) (:text |:require)
+                |j $ {} (:type :expr) (:by |u0) (:at 1617208840723)
+                  :data $ {}
+                    |T $ {} (:type :leaf) (:by |u0) (:at 1617208846004) (:text |app.lib)
+                    |j $ {} (:type :leaf) (:by |u0) (:at 1617208847109) (:text |:refer)
+                    |r $ {} (:type :expr) (:by |u0) (:at 1617208847288)
+                      :data $ {}
+                        |T $ {} (:type :leaf) (:by |u0) (:at 1617208848411) (:text |v)
+                |r $ {} (:type :expr) (:by |u0) (:at 1617208849294)
+                  :data $ {}
+                    |T $ {} (:type :leaf) (:by |u0) (:at 1617208850697) (:text |app.lib)
+                    |j $ {} (:type :leaf) (:by |u0) (:at 1617208851223) (:text |:as)
+                    |r $ {} (:type :leaf) (:by |u0) (:at 1617208851771) (:text |lib)
         :defs $ {}
           |main! $ {} (:type :expr) (:by |u0) (:at 1616315475196)
             :data $ {}
@@ -91,6 +106,16 @@
                           |x $ {} (:type :leaf) (:by |u0) (:at 1617127394539) (:text |4)
                       |r $ {} (:type :leaf) (:by |u0) (:at 1617127395790) (:text |1)
                       |v $ {} (:type :leaf) (:by |u0) (:at 1617127396687) (:text |3)
+              |yyxj $ {} (:type :expr) (:by |u0) (:at 1617211376920)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1617211377533) (:text |echo)
+                  |j $ {} (:type :leaf) (:by |u0) (:at 1617211379819) (:text "|\"local")
+                  |r $ {} (:type :leaf) (:by |u0) (:at 1617211382507) (:text |w)
+              |yyy $ {} (:type :expr) (:by |u0) (:at 1617208833388)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1617208833881) (:text |echo)
+                  |j $ {} (:type :leaf) (:by |u0) (:at 1617208857008) (:text |lib/v)
+                  |b $ {} (:type :leaf) (:by |u0) (:at 1617212612749) (:text "|\"import ns")
               |yyT $ {} (:type :expr) (:by |u0) (:at 1617126701275)
                 :data $ {}
                   |T $ {} (:type :leaf) (:by |u0) (:at 1617126702004) (:text |echo)
@@ -195,6 +220,11 @@
                           |r $ {} (:type :leaf) (:by |u0) (:at 1617125967960) (:text |2)
                           |v $ {} (:type :leaf) (:by |u0) (:at 1617125968235) (:text |3)
                           |x $ {} (:type :leaf) (:by |u0) (:at 1617125968543) (:text |4)
+              |yyxT $ {} (:type :expr) (:by |u0) (:at 1617208883507)
+                :data $ {}
+                  |T $ {} (:type :leaf) (:by |u0) (:at 1617208883507) (:text |echo)
+                  |j $ {} (:type :leaf) (:by |u0) (:at 1617208883507) (:text "|\"import")
+                  |r $ {} (:type :leaf) (:by |u0) (:at 1617208883507) (:text |v)
           |fibo $ {} (:type :expr) (:by |u0) (:at 1616914713780)
             :data $ {}
               |T $ {} (:type :leaf) (:by |u0) (:at 1616914713780) (:text |defn)
@@ -236,7 +266,26 @@
                   |j $ {} (:type :leaf) (:by |u0) (:at 1616991550493) (:text "|\"calling fibo")
                   |r $ {} (:type :leaf) (:by |u0) (:at 1616991864617) (:text |n)
                   |D $ {} (:type :leaf) (:by |u0) (:at 1616994589710) (:text |;)
+          |w $ {} (:type :expr) (:by |u0) (:at 1617211365026)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1617211368009) (:text |def)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1617211371533) (:text "|\"TODO w")
+              |r $ {} (:type :leaf) (:by |u0) (:at 1617211373227) (:text |10)
         :proc $ {} (:type :expr) (:by |u0) (:at 1616315471762)
+          :data $ {}
+        :configs $ {}
+      |app.lib $ {}
+        :ns $ {} (:type :expr) (:by |u0) (:at 1617208813912)
+          :data $ {}
+            |T $ {} (:type :leaf) (:by |u0) (:at 1617208813912) (:text |ns)
+            |j $ {} (:type :leaf) (:by |u0) (:at 1617208813912) (:text |app.lib)
+        :defs $ {}
+          |v $ {} (:type :expr) (:by |u0) (:at 1617208821938)
+            :data $ {}
+              |T $ {} (:type :leaf) (:by |u0) (:at 1617208824697) (:text |def)
+              |j $ {} (:type :leaf) (:by |u0) (:at 1617211345810) (:text "|\"TODO v")
+              |r $ {} (:type :leaf) (:by |u0) (:at 1617208825999) (:text |1)
+        :proc $ {} (:type :expr) (:by |u0) (:at 1617208813912)
           :data $ {}
         :configs $ {}
   :configs $ {} (:reload-fn |app.main/reload!)

--- a/example/compact.cirru
+++ b/example/compact.cirru
@@ -5,7 +5,10 @@
     :version |0.0.1
   :files $ {}
     |app.main $ {}
-      :ns $ quote (ns app.main)
+      :ns $ quote
+        ns app.main $ :require
+          app.lib :refer $ v
+          app.lib :as lib
       :defs $ {}
         |main! $ quote
           defn main! ()
@@ -27,10 +30,20 @@
             &let
               a $ &+ 1 2
               echo a
+            echo "\"import" v
+            echo "\"local" w
+            echo "\"import ns" lib/v
         |fibo $ quote
           defn fibo (n) (; echo "\"calling fibo" n)
             if (&< n 2) 1 $ &+
               fibo $ &- n 1
               fibo $ &- n 2
+        |w $ quote (def "\"TODO w" 10)
+      :proc $ quote ()
+      :configs $ {}
+    |app.lib $ {}
+      :ns $ quote (ns app.lib)
+      :defs $ {}
+        |v $ quote (def "\"TODO v" 1)
       :proc $ quote ()
       :configs $ {}

--- a/src/calcit/builtin.purs
+++ b/src/calcit/builtin.purs
@@ -17,7 +17,7 @@ import Data.Tuple (Tuple(..))
 import Effect (Effect)
 import Effect.Class.Console (log)
 import Effect.Exception (throw)
-import Prelude (bind, discard, pure, unit, ($), (+), (-), (<), (<>), (==), (>), (||))
+import Prelude (bind, discard, pure, ($), (+), (-), (<), (<>), (==), (>), (||))
 
 calcitAsNumber :: CalcitData -> Effect Number
 calcitAsNumber x = case x of
@@ -148,7 +148,7 @@ syntaxDefn xs scope evalFn =
       Just v -> pure v
       Nothing -> throw "function name not found"
     name <- case nameNode of
-      CalcitSymbol s -> pure s
+      CalcitSymbol s ns -> pure s
       _ -> throw "function name not a symbol"
     argsNode <- case xs !! 1 of
       Just v -> pure v
@@ -162,7 +162,7 @@ syntaxDefn xs scope evalFn =
   where
     extractArgName :: CalcitData -> Effect String
     extractArgName arg = case arg of
-      CalcitSymbol s -> pure s
+      CalcitSymbol s ns -> pure s
       _ -> throw "expected symbol"
 
 syntaxIf :: (Array CalcitData) -> CalcitScope -> FnEvalFn -> Effect CalcitData
@@ -183,7 +183,7 @@ syntaxNativeLet xs scope evalFn = do
   pair <- case xs !! 0 of
     Just (CalcitList ys) -> if (Array.length ys) == 2
       then case (ys !! 0), (ys !! 1) of
-        Just (CalcitSymbol s), Just v ->
+        Just (CalcitSymbol s ns), Just v ->
           pure { k: s, v: v }
         _, _ -> throw "expected symbol in &let"
       else throw "expected pair length of 2"

--- a/src/calcit/program.purs
+++ b/src/calcit/program.purs
@@ -3,9 +3,11 @@ module Calcit.Program where
 
 import Data.Unit
 
-import Calcit.Primes (CalcitData(..), CalcitFailure, cirruToCalcit, CalcitScope)
+import Calcit.Primes (CalcitData(..), CalcitFailure, CalcitScope, cirruToCalcit)
 import Calcit.Snapshot (Snapshot)
-import Cirru.Node (CirruNode)
+import Cirru.Node (CirruNode(..), isCirruLeaf)
+import Data.Array (length, (!!), all)
+import Data.Array as Array
 import Data.Either (Either(..))
 import Data.Map as Map
 import Data.Map.Internal as MapInternal
@@ -15,7 +17,7 @@ import Data.Traversable (traverse)
 import Data.Tuple (Tuple(..))
 import Effect (Effect)
 import Effect.Ref as Ref
-import Prelude (bind, pure)
+import Prelude (bind, pure, (==))
 
 data ImportRule = ImportNsRule String | ImportDefRule String String
 
@@ -36,13 +38,44 @@ instance showImportRule :: Show ImportRule where
 programEvaledData :: Effect (Ref.Ref (Map.Map String (Map.Map String CalcitData)))
 programEvaledData = Ref.new (Map.fromFoldable [])
 
--- | TODO crossing namespaces
-extractImportRule :: CirruNode -> Either CalcitFailure (Array (Tuple String ImportRule))
-extractImportRule edn = Right [(Tuple "TODO" (ImportNsRule "TODO"))]
+filterLeaf :: CirruNode -> Maybe String
+filterLeaf node = case node of
+  CirruLeaf x -> Just x
+  _ -> Nothing
+
+-- | parse (n.a :as b) and (n.a :refer (b c d))
+extractImportRule :: CirruNode -> String -> Either CalcitFailure (Array (Tuple String ImportRule))
+extractImportRule node ns = case node of
+  CirruLeaf s -> Left { message: "expected import rule in list", data: CalcitSymbol s ns }
+  CirruList xs -> if (length xs) == 3
+    then case xs !! 1 of
+      Just (CirruLeaf ":as") -> case (xs !! 0), (xs !! 2) of
+        Just (CirruLeaf target), Just (CirruLeaf alias) -> Right [Tuple alias (ImportNsRule target)]
+        _, _ -> Left { message: "invalid :as rule", data: cirruToCalcit node ns }
+      Just (CirruLeaf ":refer") -> case (xs !! 0), (xs !! 2) of
+        Just (CirruLeaf target), Just (CirruList ys) -> if all isCirruLeaf ys
+          then Right (Array.mapMaybe (\alias ->
+              Just (Tuple alias (ImportDefRule target alias))
+            ) (Array.mapMaybe filterLeaf ys))
+          else Left { message: "invalid :refer names, expected all leaves", data: cirruToCalcit node ns }
+        _, _ -> Left { message: "invalid :refer rule", data: cirruToCalcit node ns}
+      _ -> Left { message: "unknown import rule", data: cirruToCalcit node ns }
+    else Left { message: "expected import rule in length 3", data: cirruToCalcit node ns }
 
 -- | TODO
-extractImportMap :: CirruNode -> Either CalcitFailure (Map.Map String ImportRule)
-extractImportMap edn = Right (Map.fromFoldable [])
+extractImportMap :: CirruNode -> String -> Either CalcitFailure (Map.Map String ImportRule)
+extractImportMap node ns = case node of
+  CirruLeaf s -> Left { message: "ns rule expects a list", data: cirruToCalcit node ns }
+  CirruList xs -> case (xs !! 0), (xs !! 1), (xs !! 2) of
+    Just (CirruLeaf _), Just (CirruLeaf _), Just (CirruList ys) ->
+      if (ys !! 0) == Just (CirruLeaf ":require")
+      then case traverse (\line -> extractImportRule line ns) (Array.drop 1 ys) of
+        Right zs -> Right (Map.fromFoldable (Array.concat zs))
+        Left failure -> Left failure
+      else Left { message: "expected :require field", data: cirruToCalcit (CirruList ys) ns}
+    Just (CirruLeaf _), Just (CirruLeaf _), Nothing -> Right (Map.fromFoldable [])
+    _, _, _ -> Left { message: "invalid ns format", data: cirruToCalcit node ns}
+
 
 extractProgramData :: Snapshot -> Either CalcitFailure ProgramCodeData
 extractProgramData s =
@@ -52,13 +85,13 @@ extractProgramData s =
       fileInfo <- case Map.lookup ns s.files of
         Just file -> Right file
         Nothing -> Left { message: "cannot find ns in map", data: CalcitNil }
-      importMap <- extractImportMap fileInfo.ns
+      importMap <- extractImportMap fileInfo.ns ns
       let file = {
         -- TODO parse from rules
         importMap: importMap,
         defs: Map.mapMaybe (\x -> Just (cirruToCalcit x ns)) fileInfo.defs
       }
-      Right (Tuple ns file)
+      pure (Tuple ns file)
   in
     -- use internal for list
     case traverse getFileTuple (MapInternal.keys s.files) of
@@ -69,6 +102,22 @@ lookupDef :: String -> String -> ProgramCodeData -> Maybe (CalcitData)
 lookupDef ns def p = do
   file <- Map.lookup ns p
   Map.lookup def file.defs
+
+lookupDefTargetInImport :: String -> String -> ProgramCodeData -> Maybe String
+lookupDefTargetInImport ns def p = do
+  file <- Map.lookup ns p
+  importRule <- Map.lookup def file.importMap
+  case importRule of
+    ImportDefRule target _ -> Just target
+    ImportNsRule _ -> Nothing
+
+lookupNsTargetInImport :: String -> String -> ProgramCodeData -> Maybe String
+lookupNsTargetInImport ns name p = do
+  file <- Map.lookup ns p
+  importRule <- Map.lookup name file.importMap
+  case importRule of
+    ImportDefRule _ _ -> Nothing
+    ImportNsRule target -> Just target
 
 lookupEvaledDef :: String -> String -> Effect (Maybe CalcitData)
 lookupEvaledDef ns def = do

--- a/src/calcit/program.purs
+++ b/src/calcit/program.purs
@@ -56,12 +56,9 @@ extractProgramData s =
       let file = {
         -- TODO parse from rules
         importMap: importMap,
-        defs: Map.mapMaybe cirruToMaybeCalcit fileInfo.defs
+        defs: Map.mapMaybe (\x -> Just (cirruToCalcit x ns)) fileInfo.defs
       }
       Right (Tuple ns file)
-
-    cirruToMaybeCalcit :: CirruNode -> Maybe CalcitData
-    cirruToMaybeCalcit x = Just (cirruToCalcit x)
   in
     -- use internal for list
     case traverse getFileTuple (MapInternal.keys s.files) of

--- a/src/calcit/runner.purs
+++ b/src/calcit/runner.purs
@@ -30,7 +30,7 @@ evaluateExpr xs scope ns programData = case xs of
   CalcitNil -> pure xs
   CalcitBool _ -> pure xs
   CalcitNumber n -> pure (CalcitNumber n)
-  CalcitSymbol s -> case Map.lookup s coreNsDefs of
+  CalcitSymbol s symbolNs -> case Map.lookup s coreNsDefs of
     Just v -> pure v
     Nothing -> case Map.lookup s scope of
       Just v -> pure v
@@ -40,9 +40,9 @@ evaluateExpr xs scope ns programData = case xs of
           Just defData -> pure defData
           Nothing -> case lookupDef coreNs s programData of
             Just code -> evaluateNewDef code emptyScope coreNs s programData
-            Nothing -> case lookupDef ns s programData of
-              Just code -> evaluateNewDef code emptyScope ns s programData
-              Nothing -> throw $ "Unknown operator: " <> ns <> "/" <> s
+            Nothing -> case lookupDef symbolNs s programData of
+              Just code -> evaluateNewDef code emptyScope symbolNs s programData
+              Nothing -> throw $ "Unknown operator: " <> symbolNs <> "/" <> s
   CalcitKeyword _ -> pure xs
   CalcitString _ -> pure xs
   CalcitFn _ _ -> pure xs
@@ -59,7 +59,7 @@ evaluateExpr xs scope ns programData = case xs of
         CalcitSyntax _ f -> f (Array.drop 1 ys) scope evalFn
           where
             evalFn zs s2 = evaluateExpr zs s2 ns programData
-        CalcitSymbol s -> throw "cannot use symbol as function"
+        CalcitSymbol s _ -> throw "cannot use symbol as function"
         _ -> throw "Unknown type of operation"
   _ -> throw $ "Unexpected structure: " <> (show xs)
 

--- a/src/calcit/runner.purs
+++ b/src/calcit/runner.purs
@@ -2,7 +2,7 @@ module Calcit.Runner where
 
 import Calcit.Builtin (coreNsDefs)
 import Calcit.Primes (CalcitData(..), CalcitScope, coreNs, emptyScope)
-import Calcit.Program (ProgramCodeData, extractProgramData, lookupDef, lookupEvaledDef, writeEvaledDef)
+import Calcit.Program (ProgramCodeData, extractProgramData, lookupDef, lookupDefTargetInImport, lookupEvaledDef, lookupNsTargetInImport, programEvaledData, writeEvaledDef)
 import Calcit.Snapshot (Snapshot, loadSnapshotData)
 import Cirru.Edn (parseCirruEdn)
 import Data.Array ((!!))
@@ -11,13 +11,15 @@ import Data.Either (Either(..))
 import Data.Map as Map
 import Data.Maybe (Maybe(..))
 import Data.String (Pattern(..), split)
+import Data.String as String
 import Data.Traversable (traverse)
+import Data.Tuple (Tuple(..))
 import Effect (Effect)
 import Effect.Console (log)
 import Effect.Exception (throw)
 import Node.Encoding (Encoding(..))
 import Node.FS.Sync (readTextFile)
-import Prelude (Unit, bind, discard, pure, show, ($), (<>))
+import Prelude (Unit, bind, discard, pure, show, ($), (<>), (<), (>), (&&), (-), (>=))
 
 evaluateNewDef :: CalcitData -> CalcitScope -> String -> String -> ProgramCodeData -> Effect CalcitData
 evaluateNewDef xs scope ns def programData = do
@@ -25,24 +27,49 @@ evaluateNewDef xs scope ns def programData = do
   writeEvaledDef ns def newV
   pure newV
 
+
+evalSymbolFromProgram :: String -> CalcitScope -> String -> ProgramCodeData -> Effect CalcitData
+evalSymbolFromProgram s scope symbolNs programData = do
+  -- log $ "handling: " <> s <> " " <> symbolNs
+  v <- lookupEvaledDef symbolNs s
+  case v of
+    Just defData -> pure defData
+    Nothing -> case lookupDef symbolNs s programData of
+      Just code -> evaluateNewDef code emptyScope symbolNs s programData
+      Nothing -> throw $ "Unknown operator: " <> symbolNs <> "/" <> s
+
+parseManualNs :: String -> Maybe (Tuple String String)
+parseManualNs s = do
+  idx <- String.indexOf (Pattern "/") s
+  let size = String.length s
+  if size >= 3 && idx > 0 && idx < (size - 1)
+    then case String.split (Pattern "/") s of
+      [ns, def] -> Just (Tuple ns def)
+      _ -> Nothing
+    else Nothing
+
 evaluateExpr :: CalcitData -> CalcitScope -> String -> ProgramCodeData -> Effect CalcitData
 evaluateExpr xs scope ns programData = case xs of
   CalcitNil -> pure xs
   CalcitBool _ -> pure xs
   CalcitNumber n -> pure (CalcitNumber n)
-  CalcitSymbol s symbolNs -> case Map.lookup s coreNsDefs of
-    Just v -> pure v
-    Nothing -> case Map.lookup s scope of
+  CalcitSymbol s symbolNs -> case parseManualNs s of
+    Just (Tuple nsAlias def) -> case lookupNsTargetInImport ns nsAlias programData of
+      Just target -> evalSymbolFromProgram def scope target programData
+      Nothing -> throw $ "cannot find target " <> s
+    Nothing -> case Map.lookup s coreNsDefs of
       Just v -> pure v
-      Nothing -> do
-        v <- lookupEvaledDef ns s
-        case v of
-          Just defData -> pure defData
-          Nothing -> case lookupDef coreNs s programData of
-            Just code -> evaluateNewDef code emptyScope coreNs s programData
-            Nothing -> case lookupDef symbolNs s programData of
-              Just code -> evaluateNewDef code emptyScope symbolNs s programData
-              Nothing -> throw $ "Unknown operator: " <> symbolNs <> "/" <> s
+      Nothing -> case lookupDef coreNs s programData of
+        Just code -> evaluateNewDef code emptyScope coreNs s programData
+        Nothing -> case Map.lookup s scope of
+          Just v -> pure v
+          Nothing -> case lookupDefTargetInImport symbolNs s programData of
+            Just target -> do
+              -- log $ "from imported ns: " <> target <> " " <> (show programData)
+              evalSymbolFromProgram s scope target programData
+            Nothing -> do
+              -- log $ "from local ns:" <> s
+              evalSymbolFromProgram s scope symbolNs programData
   CalcitKeyword _ -> pure xs
   CalcitString _ -> pure xs
   CalcitFn _ _ -> pure xs

--- a/src/includes/calcit-core.cirru
+++ b/src/includes/calcit-core.cirru
@@ -32,5 +32,8 @@
           defn butlast (xs)
             slice xs 0 (dec (count xs))
 
+        |def $ quote
+          defn def (name v) v
+
       :proc $ quote ()
       :configs $ {}


### PR DESCRIPTION
由于 macro 当中要处理 hygienic macro 的问题, 参考之前的 calcit-runner Nim 版本实现, 需要加上 `ns` 信息.

代码当中还有一个 `.resolved` 字段包含 `.ns` 等信息. 所以 symbol 上最终版本有两个 `ns`. 区别是, `symbol.ns` 对应符号创建时的 namespace, 用于 eval 当中查找函数引用, 而 `symbol.resolved.ns` 是根据 import 规则解析以后最终的 namespace, 这个信息对于 codegen 来说比较实用.

此前版本 calcit-runner 实现的时候没有想得足够清楚. 目前这个仓库没有 codegen 的计划, 所以按道理, 一分 `symbol.ns` 信息应当足够.
